### PR TITLE
fix(bluebird): Add bluebird to APOD library

### DIFF
--- a/src/libraries/apod.js
+++ b/src/libraries/apod.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Bluebird = require('bluebird');
+
 const Config = require('../../config');
 
 const RETRY_MS      = 900000; // 15 minutes


### PR DESCRIPTION
- [x] Require Bluebird (which was forgotten in [the last PR](https://github.com/mpiercy827/aapod-api/pull/13))