### PR TITLE
feat(seed): Only seed db if media records are not present

### DIFF
--- a/src/libraries/dbSeeder.js
+++ b/src/libraries/dbSeeder.js
@@ -5,6 +5,8 @@ const Moment   = require('moment');
 
 const Download = require('./download');
 
+const Media = require('../models/media').Media;
+
 const FIRST_APOD_DATE = Moment.utc('1995-06-16');
 
 exports.seed = () => {
@@ -18,6 +20,13 @@ exports.seed = () => {
     date.subtract(1, 'days');
   }
 
-  return Bluebird.each(dates, Download.download);
+  return Bluebird.each(dates, (date) => {
+    return new Media({ date: date }).fetch()
+    .then((media) => {
+      if (!media) {
+        return Download.download(date);
+      }
+    });
+  });
 };
 

--- a/test/libraries/dbSeeder.test.js
+++ b/test/libraries/dbSeeder.test.js
@@ -3,18 +3,33 @@
 const Sinon = require('sinon');
 const Bluebird = require('bluebird');
 
+const Knex     = require('../../db').Knex;
 const Download = require('../../src/libraries/download');
 const DBSeeder = require('../../src/libraries/dbSeeder');
 
+const DefaultMedia = {
+  date: '2017-05-07',
+  url: 'https://apod.nasa.gov/apod/image/1705/ic410_WISEantonucci_960.jpg',
+  type: 'image'
+};
+
 describe('DBSeeder', () => {
+
+  beforeEach(() => {
+    return Knex('media').truncate()
+    .then(() => {
+      return Knex('media').insert(DefaultMedia);
+    });
+  });
 
   describe('seed', () => {
 
-    it('seeds the database with all APOD media', () => {
+    it('seeds the database with all APOD media, unless already present', () => {
       const downloadStub = Sinon.stub(Download, 'download').returns(Bluebird.resolve({}));
 
       return DBSeeder.seed()
       .then(() => {
+        expect(downloadStub).to.not.have.been.calledWith('2017-05-07');
         expect(downloadStub).to.have.been.calledWith('2017-05-03');
         expect(downloadStub).to.have.been.calledWith('1995-06-20');
         expect(downloadStub).to.have.been.calledWith('1995-06-16');


### PR DESCRIPTION
The APOD API went down for parts of the seeding, so I need to reseed, but only for days where the media records are not present.