### PR TITLE
feat(text): Make copyright, title and url columns text

### DIFF
--- a/db/migrations/20170514102858_varchar_to_text.js
+++ b/db/migrations/20170514102858_varchar_to_text.js
@@ -1,0 +1,17 @@
+'use strict';
+
+exports.up = function(Knex, Promise) {
+  return Knex.raw(`ALTER TABLE media
+    ALTER COLUMN copyright SET DATA TYPE text,
+    ALTER COLUMN title SET DATA TYPE text,
+    ALTER COLUMN url SET DATA TYPE text;
+  `);
+};
+
+exports.down = function(Knex, Promise) {
+  return Knex.raw(`ALTER TABLE media
+    ALTER COLUMN copyright SET DATA TYPE varchar(100),
+    ALTER COLUMN title SET DATA TYPE varchar(100),
+    ALTER COLUMN url SET DATA TYPE varchar(200);
+  `);
+};


### PR DESCRIPTION
- [x] Alleviates some of the seeding errors that were resulting from a copyright being much larger than 100 characters.