### PR TITLE
fix(download): Change criteria for avoiding duplicate downloads

### DIFF
--- a/src/libraries/download.js
+++ b/src/libraries/download.js
@@ -16,7 +16,12 @@ const URL_BASE = 'https://s3-us-west-2.amazonaws.com/';
 exports.download = (date) => {
   return APOD.fetch(date)
   .then((response) => {
-    return new Media({date: response.date}).fetch()
+    return new Media({
+      title: response.title,
+      type: response.media_type,
+      description: response.explanation
+    })
+    .fetch()
     .then((media) => {
       return media ? {} : response;
     });

--- a/test/libraries/download.test.js
+++ b/test/libraries/download.test.js
@@ -46,9 +46,9 @@ describe('Downlaod', () => {
     });
 
     it('does not duplicate media', () => {
-      return Download.download('2016-05-11')
+      return Download.download()
       .then(() => {
-        return Download.download('2016-05-11');
+        return Download.download();
       })
       .then((result) => {
         expect(result).to.not.exist;


### PR DESCRIPTION
It turns out there is an issue with the APOD API (that was causing an issue in the AAPOD API) where the previous day's response was duplicated at 00:00UTC until the next day's content was uploaded. However, the date changed, so this was causing us to duplicate media records.

This checks to see if there is a record with the same title, description and media type, which will be a better check against duplicates.